### PR TITLE
Add assertions to enforce program state

### DIFF
--- a/src/main/java/duke/Storage.java
+++ b/src/main/java/duke/Storage.java
@@ -73,10 +73,13 @@ public class Storage {
     private Task parseTaskData(String[] data) {
         switch (data[0]) {
         case "T":
+            assert data.length == 3 : "todo data should have 3 parts";
             return new Todo(data[2], Boolean.parseBoolean(data[1]));
         case "D":
+            assert data.length == 4 : "deadline data should have 4 parts";
             return new Deadline(data[2], Boolean.parseBoolean(data[1]), data[3]);
         default:
+            assert data.length == 5 : "event data should have 5 parts";
             return new Event(data[2], Boolean.parseBoolean(data[1]), data[3], data[4]);
         }
     }

--- a/src/main/java/duke/command/CreateDeadlineCommand.java
+++ b/src/main/java/duke/command/CreateDeadlineCommand.java
@@ -42,6 +42,7 @@ public class CreateDeadlineCommand extends Command {
     public String execute() {
         try {
             String[] commandMessageArr = commandMessage.split("/", 2);
+            assert commandMessageArr.length == 2 : "deadline command should split into 2";
             Task task = new Deadline(commandMessageArr[0].substring(9), false,
                     commandMessageArr[1].substring(3));
 

--- a/src/main/java/duke/command/CreateEventCommand.java
+++ b/src/main/java/duke/command/CreateEventCommand.java
@@ -42,6 +42,7 @@ public class CreateEventCommand extends Command {
     public String execute() {
         try {
             String[] commandMessageArr = commandMessage.split("/", 3);
+            assert commandMessageArr.length == 3 : "event command should split into 3";
             Task task = new Event(commandMessageArr[0].substring(6), false,
                     commandMessageArr[1].substring(5).trim(),
                     commandMessageArr[2].substring(3));

--- a/src/main/java/duke/command/CreateTodoCommand.java
+++ b/src/main/java/duke/command/CreateTodoCommand.java
@@ -42,6 +42,7 @@ public class CreateTodoCommand extends Command {
     public String execute() {
         try {
             String[] commandMessageArr = commandMessage.split(" ", 2);
+            assert commandMessageArr.length == 2 : "todo command should split into 2";
             Task task = new Todo(commandMessageArr[1], false);
 
             taskList.addTask(task);

--- a/src/main/java/duke/command/DeleteTaskCommand.java
+++ b/src/main/java/duke/command/DeleteTaskCommand.java
@@ -42,6 +42,7 @@ public class DeleteTaskCommand extends Command {
     public String execute() {
         try {
             String[] commandMessageArr = commandMessage.split(" ", 2);
+            assert commandMessageArr.length == 2 : "delete command should split into 2";
             int taskNumber = Integer.parseInt(commandMessageArr[1]);
             Task task = taskList.deleteTask(taskNumber);
 

--- a/src/main/java/duke/command/MarkTaskCommand.java
+++ b/src/main/java/duke/command/MarkTaskCommand.java
@@ -40,6 +40,7 @@ public class MarkTaskCommand extends Command {
     public String execute() {
         try {
             String[] commandMessageArr = commandMessage.split(" ", 2);
+            assert commandMessageArr.length == 2 : "mark command should split into 2";
             int taskNumber = Integer.parseInt(commandMessageArr[1]);
             Task task = taskList.markTask(taskNumber);
 

--- a/src/main/java/duke/command/UnmarkTaskCommand.java
+++ b/src/main/java/duke/command/UnmarkTaskCommand.java
@@ -40,6 +40,7 @@ public class UnmarkTaskCommand extends Command {
     public String execute() {
         try {
             String[] commandMessageArr = commandMessage.split(" ", 2);
+            assert commandMessageArr.length == 2 : "unmark command should split into 2";
             int taskNumber = Integer.parseInt(commandMessageArr[1]);
             Task task = taskList.unmarkTask(taskNumber);
 


### PR DESCRIPTION
Command messages should have the correct amount of dividers so assertions are used to check if there
is a correct amount of parts after splitting the
command messages.